### PR TITLE
Escape vertical bar character.

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -6,5 +6,5 @@ exports.escape = escape;
 Escape special markdown characters
 */
 function escape(input){
-    return input.replace(/\*/g, "\\*");
+    return input.replace(/([\*|])/g, "\\$1");
 }


### PR DESCRIPTION
This ensures the pipe character inside param definitions or descriptions doesn't interfere with markdown tables (which use pipes to delimit cells):

```javascript
// @param {Array.<Number|String>}
```