### PR TITLE
Escape vertical bar character.

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -11,7 +11,7 @@ Escape special markdown characters
 */
 function escape(input){
     if (typeof input !== "string") return null;
-    return input.replace(/\*/g, "\\*");
+    return input.replace(/([\*|])/g, "\\$1");
 }
 
 function linkify(text, options){


### PR DESCRIPTION
This ensures the pipe character inside param definitions or descriptions doesn't interfere with markdown tables (which use pipes to delimit cells):

```javascript
// @param {Array.<Number|String>}
```