### PR TITLE
Class name starting with multiple upper-case letters

### DIFF
--- a/helpers/parent-name.js
+++ b/helpers/parent-name.js
@@ -1,7 +1,9 @@
 var a = require("array-tools");
 
 function instantiate(input){
-    return input.charAt(0).toLowerCase() + input.slice(1);
+    return input.replace(/^([A-Z]+)([A-Z])/, function (str, p1, p2) {
+        return p1.toLowerCase() + p2;
+    });
 }
 
 module.exports = function(handlebars){

--- a/test/fixture/camelcase.json
+++ b/test/fixture/camelcase.json
@@ -1,0 +1,21 @@
+[
+  {
+    "description": "this module exports a class constructor",
+    "kind": "module",
+    "name": "JSONParser",
+    "examples": [
+      "```js\nvar JSONParser = require(\"json-parser\");\n```"
+    ],
+    "longname": "module:json-parser"
+  },
+  {
+    "description": "A prototype instance methy meth",
+    "params": [],
+    "name": "parse",
+    "longname": "module:json-parser#parse",
+    "kind": "function",
+    "memberof": "module:json-parser",
+    "scope": "instance",
+    "codeName": "JSONParser.prototype.parse"
+  }
+]

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,15 @@ test("linkify", function (t) {
 
 });
 
+test("camel case", function(t){
+    t.plan(1);
+
+    fs.createReadStream("test/fixture/camelcase.json").pipe(dmd()).on("readable", function(){
+        var md = this.read();
+        if (md) t.ok(/jsonParser.parse/.test(md.toString()));
+    });
+});
+
 test("partials");
 test("headers");
 test("plugins");


### PR DESCRIPTION
When generating instance name from class name, the name starting with multiple upper-case letters is converted as below.
```
JSONParser -> jSONParser
```

So I improved helper function to generate correct camel-case instance name as below.
```
JSONParser -> jsonParser
```