### PR TITLE
linkify helper to return safe string

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -33,7 +33,7 @@ function linkify(text, options){
             text = text.replace(link.original, "[" + link.caption + "](" + link.url + ")");
         });
     }
-    return text;
+    return new handlebars.SafeString(text);
 }
 
 function tableHead(){


### PR DESCRIPTION
When chaining helpers linkify returns an already escaped string. This is problematic when trying to chain the helper to another one (ex: `{{{customHelper (linkify description)}}}` <- description will be received already escaped in `customHelper`